### PR TITLE
fix:#14 Enable builds from within containers

### DIFF
--- a/dotnet/Metaparticle.Package/Metaparticle.cs
+++ b/dotnet/Metaparticle.Package/Metaparticle.cs
@@ -134,9 +134,13 @@ namespace Metaparticle.Package
 
         public static bool InDockerContainer()
         {
-            var inContainer = System.Environment.GetEnvironmentVariable("METAPARTICLE_IN_CONTAINER");
-            if ("true".Equals(inContainer)) {
-                return true;
+            switch (System.Environment.GetEnvironmentVariable("METAPARTICLE_IN_CONTAINER")) {
+                case "true":
+                case "1":
+                    return true;
+                case "false":
+                case "0":
+                    return false;
             }
             // This only works on Linux
             const string cgroupPath = "/proc/1/cgroup";

--- a/java/src/main/java/io/metaparticle/Metaparticle.java
+++ b/java/src/main/java/io/metaparticle/Metaparticle.java
@@ -16,8 +16,13 @@ import static io.metaparticle.Util.once;
 public class Metaparticle {
 
     public static boolean inDockerContainer() {
-        if ("true".equals(System.getenv("METAPARTICLE_IN_CONTAINER"))) {
-            return true;
+        switch (System.getenv("METAPARTICLE_IN_CONTAINER")) {
+            case "true":
+            case "1":
+                return true;
+            case "false":
+            case "0":
+                return false;
         }
         File f = new File("/proc/1/cgroup");
         if (f.exists()) {

--- a/javascript/metaparticle-package/index.js
+++ b/javascript/metaparticle-package/index.js
@@ -2,9 +2,14 @@
     var fs = require('fs');
     var path = require('path');
 
-    inDocker = () => {
-        if (process.env.METAPARTICLE_IN_CONTAINER === "true") {
-            return true;
+    inDockerContainer = () => {
+        switch (process.env.METAPARTICLE_IN_CONTAINER) {
+            case 'true':
+            case '1':
+                return true;
+            case 'false':
+            case '0':
+                return false;
         }
         var info = fs.readFileSync("/proc/1/cgroup");
         // This is a little approximate...
@@ -59,7 +64,7 @@
             fn = arg1;
             options = null;
         }
-        if (inDocker()) {
+        if (inDockerContainer()) {
             fn();
         } else {
             var dir = process.cwd();


### PR DESCRIPTION
Previously, it was impossible to override a positive heuristic from **inDockerContainer()**.
Switch on `METAPARTICLE_IN_CONTAINER` so that when it's explicitly "false", we return false and allow building in a container.

I also renamed javascript: inDocker() -> inDockerContainer() to match the interfaces from dotnet and java.

Fixes #14 
I did not test Java or Dotnet

### reproduce for javascript:
```bash
cd ${repo_root}
cp -a examples/web ../testlocaljs
sed -i '' 's|@metaparticle/package|../package/javascript/metaparticle-package|g' ../testlocaljs/index.js
```

```javascript
head ../testlocaljs/index.js

const http = require('http');
const os = require('os');
const mp = require('../package/javascript/metaparticle-package');

const port = 8080;

const server = http.createServer((request, response) => {
	console.log(request.url);
	response.end(`Hello World: hostname: ${os.hostname()}\n`);
});
```

```
docker run -itv /var/run/docker.sock:/var/run/docker.sock --rm -v $PWD:/app -w /app docker ash
/app # apk --update add nodejs
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/7) Installing libcrypto1.0 (1.0.2m-r0)
(2/7) Installing libgcc (6.3.0-r4)
(3/7) Installing http-parser (2.7.1-r1)
(4/7) Installing libssl1.0 (1.0.2m-r0)
(5/7) Installing libstdc++ (6.3.0-r4)
(6/7) Installing libuv (1.11.0-r1)
(7/7) Installing nodejs (6.10.3-r1)
Executing busybox-1.26.2-r9.trigger
OK: 26 MiB in 19 packages
/app #
/app # cd testlocaljs/
/app/testlocaljs # node index.js
server up on 8080
^C
/app/testlocaljs # METAPARTICLE_IN_CONTAINER=false node index.js
Sending build context to Docker daemon  6.144kB
Step 1/4 : FROM node:6-alpine
 ---> 29428556c0cb
Step 2/4 : COPY ./ /web/
^C
```