### PR TITLE
trivial: mvn package instlal -> mvn install

### DIFF
--- a/tutorials/java/tutorial.md
+++ b/tutorials/java/tutorial.md
@@ -24,13 +24,13 @@ get them up into Maven central shortly...
 
 git clone https://github.com/metaparticle-io/metaparticle-java
 cd metaparticle-java
-mvn package install
+mvn install
 
 # Install Metaparticle/Package
 
 git clone https://github.com/metaparticle-io/package
 cd package/java
-mvn package install
+mvn install
 ```
 
 ### Get the code


### PR DESCRIPTION
There is no need for `mvn package install` because `package` phase is run automatically when running the `install` phase.

Check http://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#A_Build_Lifecycle_is_Made_Up_of_Phases