### PR TITLE
Remove need to have privileged read access for container detection for python

### DIFF
--- a/python/metaparticle.py
+++ b/python/metaparticle.py
@@ -10,15 +10,11 @@ def is_in_docker_container():
         return False
 
     try:
-        with open('/proc/1/cgroup', 'r+t') as f:
-            lines = f.read().splitlines()
-            last_line = lines[-1]
-            if 'docker' in last_line:
-                return True
-            elif 'kubepods' in last_line:
-                return True
-            else:
+        with open('/proc/1/sched', 'rt') as f:
+            if '(1,' in f.readline():
                 return False
+            else:
+                return True
 
     except FileNotFoundError:
         return False


### PR DESCRIPTION
The issue is that `/proc/1/cgroup` can only be read by root (mentioned in #39). The proposed fix is to use a resource that anyone can access such that running this as root is not required. Taking the same approach as the `systemd-detect-virt` application (https://github.com/systemd/systemd/blob/575e6588df982e76b1f2393b26758645ceaeb892/src/basic/virt.c#L508) I think that `/proc/1/sched` should be used instead. 

The first line in `/proc/1/sched` lists the name of the first process ran in the namespace and the PID may or may not be 1. If you are on the host then the PID is 1, but if you are in a container, then the PID will not be 1... it should be the PID of the process on the hosts process table (in the parent namespace).

A bit of background here: https://lkml.org/lkml/2013/9/3/270

I realize this may be piggy-backing off of unintended behavior, however, I feel that it is the 'lesser of two evils'... let me know what you think.