### PR TITLE
Ignore missing METAPARTICLE_IN_CONTAINER env var in Java

### DIFF
--- a/java/src/main/java/io/metaparticle/Metaparticle.java
+++ b/java/src/main/java/io/metaparticle/Metaparticle.java
@@ -16,14 +16,18 @@ import static io.metaparticle.Util.once;
 public class Metaparticle {
 
     public static boolean inDockerContainer() {
-        switch (System.getenv("METAPARTICLE_IN_CONTAINER")) {
-            case "true":
-            case "1":
-                return true;
-            case "false":
-            case "0":
-                return false;
+        String envFlag = System.getenv("METAPARTICLE_IN_CONTAINER");
+        if (envFlag != null) {
+            switch (envFlag) {
+                case "true":
+                case "1":
+                    return true;
+                case "false":
+                case "0":
+                    return false;
+            }
         }
+
         File f = new File("/proc/1/cgroup");
         if (f.exists()) {
             try {


### PR DESCRIPTION
Fixes issue #36 by allowing the `inDockerContainer()` method to fall back to the automatic check if the environment variable isn't set