### PR TITLE
Replace os/exec with docker client API

### DIFF
--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/Microsoft/go-winio"
+  packages = ["."]
+  revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
+  version = "v0.4.5"
+
+[[projects]]
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
@@ -18,6 +24,29 @@
   packages = ["."]
   revision = "521b25f4b05fd26bec69d9dedeb8f9c9a83939a8"
   version = "v8"
+
+[[projects]]
+  name = "github.com/docker/distribution"
+  packages = ["digestset","reference"]
+  revision = "f4118485915abb8b163442717326597908eee6aa"
+
+[[projects]]
+  name = "github.com/docker/docker"
+  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/stdcopy","pkg/tlsconfig"]
+  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
+  version = "v1.13.1"
+
+[[projects]]
+  name = "github.com/docker/go-connections"
+  packages = ["nat","sockets","tlsconfig"]
+  revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
+  version = "v0.3.0"
+
+[[projects]]
+  name = "github.com/docker/go-units"
+  packages = ["."]
+  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
@@ -98,10 +127,28 @@
   revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
 
 [[projects]]
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","idna"]
+  packages = ["context","context/ctxhttp","idna","proxy"]
   revision = "a8b9294777976932365dabb6640cf1468d95c70f"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["windows"]
+  revision = "83801418e1b59fb1880e363299581ee543af32ca"
 
 [[projects]]
   branch = "master"
@@ -124,6 +171,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "761eee4df3f5acf639e9056d96cbd5e9dddc9273e7f2b362e38e8d26030883cf"
+  inputs-digest = "8ef9140ec1a019091120275b50eaa13014bdf78b61167414f83ea35c68dc8a88"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -24,3 +24,8 @@
 [[constraint]]
   name = "github.com/metaparticle-io/metaparticle-ast"
   version = "0.2.0"
+
+# had to override this version because of https://github.com/golang/dep/issues/1415
+[[override]]
+  name = "github.com/docker/distribution"
+  revision = "f4118485915abb8b163442717326597908eee6aa"

--- a/go/examples/webapp/main.go
+++ b/go/examples/webapp/main.go
@@ -13,19 +13,18 @@ var port int32 = 8080
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	hostname, _ := os.Hostname()
-	fmt.Fprintf(w, "Hello containers [%s] from %s", r.RequestURI, hostname)
+	fmt.Fprintf(w, "Hello metaparticle from %s!", r.RequestURI, hostname)
 }
 
 func main() {
 	metaparticle.Containerize(
 		&metaparticle.Runtime{
-			Ports:           []int32{port},
-			Shards:          0,
-			URLShardPattern: "^\\/users\\/([^\\/]*)\\/.*",
-			Executor:        "docker"},
-		&metaparticle.Package{Repository: "xfernando",
-			Builder: "docker",
-			Verbose: true},
+			Ports:    []int32{port},
+			Executor: "docker"},
+		&metaparticle.Package{Name: "metaparticle-web-demo",
+			Repository: "xfernando",
+			Builder:    "docker",
+			Verbose:    true},
 		func() {
 			log.Println("Starting server on :8080")
 			http.HandleFunc("/", handler)

--- a/go/metaparticle/docker_impl.go
+++ b/go/metaparticle/docker_impl.go
@@ -1,81 +1,288 @@
 package metaparticle
 
 import (
-	"fmt"
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
 	"io"
-	"os/exec"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
 )
 
-type DockerImpl struct{}
+// DockerImpl is a docker implementation of the Builder and Executor interfaces
+type DockerImpl struct {
+	imageClient     dockerImageClient
+	containerRunner dockerContainerRunner
+}
 
+// Docker's client.ImageAPIClient is too big, so I created this interface with the only methods needed from it.
+// This will make mocking code for tests much smaller
+type dockerImageClient interface {
+	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
+	ImagePush(ctx context.Context, ref string, options types.ImagePushOptions) (io.ReadCloser, error)
+}
+
+// Docker's client.ContainerAPIClient is too big so I created this interface with the only methods needed from it
+// This will make mocking code for tests much smaller
+type dockerContainerRunner interface {
+	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
+	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
+	ContainerStop(ctx context.Context, container string, timeout *time.Duration) error
+	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
+	ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error)
+}
+
+func newDockerImpl(imageClient dockerImageClient, containerRunner dockerContainerRunner) (*DockerImpl, error) {
+	if imageClient == nil && containerRunner == nil {
+		dockerClient, err := client.NewEnvClient()
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to create docker client")
+		}
+
+		// dockerClient implements both APIs, but having separate struct members with specific interfaces
+		// will make mocking for testing easier
+		return &DockerImpl{dockerClient, dockerClient}, nil
+	}
+
+	return &DockerImpl{imageClient, containerRunner}, nil
+}
+
+// NewDockerImpl returns a singleton struct that uses docker to implement metaparticle.Builder and metaparticle.Executor.
+//
+// It uses the environment variables DOCKER_CERT_PATH, DOCKER_HOST, DOCKER_API_VERSION and DOCKER_TLS_VERIFY
+// to instantiate instantiate a docker API client.
+// When these variables are not specified, it defaults to the client running on the local machine.
+func NewDockerImpl() (*DockerImpl, error) {
+	return newDockerImpl(nil, nil)
+}
+
+// createTarGz creates a tarball of the directory in order to send it to the docker server. It returns
+// the full path of the file created and an error
+func createTarGz(dir string) (string, error) {
+	tarball, err := ioutil.TempFile("", "context.tar.gz")
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to create temporary project tarball")
+	}
+	defer tarball.Close()
+
+	gw := gzip.NewWriter(tarball)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	err = filepath.Walk(dir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			var filePath string
+			if path != "." {
+				filePath = path
+			} else {
+				filePath = info.Name()
+			}
+			header, err := tar.FileInfoHeader(info, filePath)
+			if err != nil {
+				return errors.Wrap(err, "Error creating a file header")
+			}
+
+			if err := tw.WriteHeader(header); err != nil {
+				return errors.Wrap(err, "Error writing file header")
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			file, err := os.Open(path)
+			if err != nil {
+				return errors.Wrap(err, "Error opening temporary tarball file")
+			}
+			defer file.Close()
+			_, err = io.Copy(tw, file)
+			return err
+		})
+
+	if err != nil {
+		return "", errors.Wrap(err, "Error creating temporary tarball with project's contents")
+	}
+
+	return tarball.Name(), nil
+}
+
+// printStreamResponse decodes a json stream response from the docker server
+func printStreamResponse(body io.ReadCloser, out io.Writer) error {
+	var line struct {
+		Stream string `json:"stream"`
+	}
+	decoder := json.NewDecoder(body)
+	for {
+		err := decoder.Decode(&line)
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			break
+		}
+		out.Write([]byte(line.Stream))
+	}
+	return nil
+}
+
+// Build creates a tarball with the directory's contents and sends it to docker to be build the image
 func (d *DockerImpl) Build(dir string, image string, stdout io.Writer, stderr io.Writer) error {
 	if len(dir) == 0 {
-		return fmt.Errorf("A context directory must be specified")
+		return errEmptyContextDirectory
 	}
-	if len(image) == 0 {
-		return fmt.Errorf("An image name must be specified")
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return errInexistentContextDirectory
+		}
+		return err
 	}
-	cmd := exec.Command("docker", "build", "-t", image, dir)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
 
-	return cmd.Run()
+	if len(image) == 0 {
+		return errEmptyImageName
+	}
+
+	name, err := createTarGz(dir)
+	if err != nil {
+		return errors.Wrap(err, "Error creating temporaty tarball")
+	}
+	tarfile, err := os.Open(name)
+	if err != nil {
+		return errors.Wrap(err, "Error opening the temporary tarball")
+	}
+	defer os.Remove(name)
+	defer tarfile.Close()
+	ctx := context.Background()
+	res, err := d.imageClient.ImageBuild(ctx, tarfile, types.ImageBuildOptions{Tags: []string{image}})
+	if err != nil {
+		return errors.Wrap(err, "Error sending build request to docker")
+	}
+
+	if err = printStreamResponse(res.Body, stdout); err != nil {
+		return errors.Wrap(err, "Error reading build output from docker")
+	}
+
+	return nil
 }
 
+// Push pushes the image to the docker registry
 func (d *DockerImpl) Push(image string, stdout io.Writer, stderr io.Writer) error {
 	if len(image) == 0 {
-		return fmt.Errorf("An image name must be specified")
+		return errEmptyImageName
 	}
-	cmd := exec.Command("docker", "push", image)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	ctx := context.Background()
+	res, err := d.imageClient.ImagePush(ctx, image, types.ImagePushOptions{})
+	if res != nil {
+		defer res.Close()
+	}
+	if err != nil {
+		return errors.Wrap(err, "Error sending push request to docker")
+	}
+	if err = printStreamResponse(res, stdout); err != nil {
+		return errors.Wrap(err, "Error reading push output from docker")
+	}
 
-	return cmd.Run()
+	return nil
 }
 
+func parsePorts(ports []int32) (nat.PortMap, nat.PortSet, error) {
+	portBindings := make(nat.PortMap)
+	exposedPorts := make(nat.PortSet)
+	for _, port := range ports {
+		if port <= 0 || port > 65535 {
+			return nil, nil, errInvalidPort(port)
+		}
+		// TODO: some people might need UDP ports, will probably need to switch the slice of int32 to something else
+		natPort, err := nat.NewPort("tcp", strconv.Itoa(int(port)))
+		exposedPorts[natPort] = struct{}{}
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "Error converting the port number")
+		}
+		portBinding := []nat.PortBinding{{HostPort: strconv.Itoa(int(port))}}
+
+		portBindings[natPort] = portBinding
+	}
+
+	return portBindings, exposedPorts, nil
+}
+
+// Run creates and starts a container with the given image and name, and runtime options (e.g. exposed ports) specified in the config parameter
 func (d *DockerImpl) Run(image string, name string, config *Runtime, stdout io.Writer, stderr io.Writer) error {
 	if len(image) == 0 {
-		return fmt.Errorf("An image must be specified")
+		return errEmptyImageName
 	}
 
 	if len(name) == 0 {
-		return fmt.Errorf("The container's name must be specified")
+		return errEmptyContainerName
 	}
 
 	if config == nil {
-		return fmt.Errorf("config must not be nil")
+		return errNilRuntimeConfig
 	}
-	cmdName := "docker"
-	cmdParams := []string{"run", "-d"}
-	for _, port := range config.Ports {
-		cmdParams = append(cmdParams, "-p", fmt.Sprintf("%d:%d", port, port))
+
+	portBindings, exposedPorts, err := parsePorts(config.Ports)
+	if err != nil {
+		return errors.Wrap(err, "Error parsing configuration ports")
 	}
-	cmdParams = append(cmdParams, "--name", name, image)
 
-	cmd := exec.Command(cmdName, cmdParams...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	ctx := context.Background()
+	if _, err := d.containerRunner.ContainerCreate(ctx, &container.Config{Image: image, ExposedPorts: exposedPorts},
+		&container.HostConfig{PortBindings: portBindings}, nil, name); err != nil {
+		return errors.Wrap(err, "Error creating the container")
+	}
 
-	return cmd.Run()
+	if err := d.containerRunner.ContainerStart(ctx, name, types.ContainerStartOptions{}); err != nil {
+		return errors.Wrap(err, "Error starting the container")
+	}
+	return nil
 }
 
+// Logs attaches to the container with the given name and prints the log to stdout
 func (d *DockerImpl) Logs(name string, stdout io.Writer, stderr io.Writer) error {
 	if len(name) == 0 {
-		return fmt.Errorf("A container name must be specified")
+		return errEmptyContainerName
 	}
-	cmd := exec.Command("docker", "logs", "-f", name)
-	cmd.Stderr = stderr
-	cmd.Stdout = stdout
+	ctx := context.Background()
+	res, err := d.containerRunner.ContainerLogs(ctx, name, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true, Follow: true})
+	defer res.Close()
+	if err != nil {
+		return errors.Wrap(err, "Error getting container logs")
+	}
 
-	return cmd.Run()
+	_, err = stdcopy.StdCopy(stdout, stderr, res)
+	return err
 }
 
+// Cancel stops and removes the container with the given name
 func (d *DockerImpl) Cancel(name string) error {
-	cmd := exec.Command("docker", "stop", name)
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("Could not stop the container: %v", err)
+	if len(name) == 0 {
+		return errEmptyContainerName
 	}
-	cmd = exec.Command("docker", "rm", "-f", name)
-	return cmd.Run()
+	ctx := context.Background()
+	timeout := 60 * time.Second
+
+	if err := d.containerRunner.ContainerStop(ctx, name, &timeout); err != nil {
+		return errors.Wrap(err, "Error stopping the container")
+	}
+	if err := d.containerRunner.ContainerRemove(ctx, name, types.ContainerRemoveOptions{}); err != nil {
+		return errors.Wrap(err, "Error removing the container")
+	}
+
+	return nil
 }

--- a/go/metaparticle/docker_impl.go
+++ b/go/metaparticle/docker_impl.go
@@ -260,10 +260,10 @@ func (d *DockerImpl) Logs(name string, stdout io.Writer, stderr io.Writer) error
 	}
 	ctx := context.Background()
 	res, err := d.containerRunner.ContainerLogs(ctx, name, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true, Follow: true})
-	defer res.Close()
 	if err != nil {
 		return errors.Wrap(err, "Error getting container logs")
 	}
+	defer res.Close()
 
 	_, err = stdcopy.StdCopy(stdout, stderr, res)
 	return err

--- a/go/metaparticle/docker_impl_test.go
+++ b/go/metaparticle/docker_impl_test.go
@@ -1,0 +1,348 @@
+package metaparticle
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/pkg/errors"
+)
+
+type mockReadCloser struct {
+	*bytes.Buffer
+}
+
+func (m *mockReadCloser) Close() error {
+	return nil
+}
+
+type mockImageClient struct {
+	serverResponse string
+	serverError    error
+}
+
+func (m *mockImageClient) ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
+	if m.serverError != nil {
+		return types.ImageBuildResponse{}, m.serverError
+	}
+	body := &mockReadCloser{bytes.NewBufferString(m.serverResponse)}
+	return types.ImageBuildResponse{Body: body}, nil
+}
+
+func (m *mockImageClient) ImagePush(ctx context.Context, ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
+	if m.serverError != nil {
+		return nil, m.serverError
+	}
+
+	body := &mockReadCloser{bytes.NewBufferString(m.serverResponse)}
+	return body, nil
+}
+
+func TestDockerBuild(t *testing.T) {
+	serverErr := fmt.Errorf("Error")
+	cases := []struct {
+		name              string
+		dir               string
+		image             string
+		serverResponse    string
+		serverError       error
+		expectedError     error
+		expectedErrorType reflect.Type
+	}{
+		{
+			name:          "Test docker build - empty context directory",
+			image:         "test",
+			expectedError: errEmptyContextDirectory,
+		},
+		{
+			name:          "Test docker build - empty image name",
+			dir:           ".",
+			expectedError: errEmptyImageName,
+		},
+		{
+			name:           "Test docker build - project build",
+			dir:            "./test-data/test-project",
+			image:          "test",
+			serverResponse: `{"stream":"Build successful"}`,
+		},
+		{
+			name:          "Test docker build - inexistent project directory",
+			dir:           "./test-data/aknADKASj",
+			image:         "test",
+			expectedError: errInexistentContextDirectory,
+		},
+		{
+			name:              "Test garbled server response",
+			dir:               "./test-data/test-project",
+			image:             "test",
+			serverResponse:    `f9q*sa9das}`,
+			expectedErrorType: reflect.TypeOf(&json.SyntaxError{}),
+		},
+		{
+			name:          "Test server error",
+			dir:           "./test-data/test-project",
+			image:         "test",
+			serverError:   serverErr,
+			expectedError: serverErr,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mockDockerImpl, _ := newDockerImpl(&mockImageClient{c.serverResponse, c.serverError}, nil)
+			err := mockDockerImpl.Build(c.dir, c.image, os.Stdout, os.Stderr)
+			cause := errors.Cause(err)
+			if c.expectedErrorType != nil {
+				if reflect.TypeOf(cause) != c.expectedErrorType {
+					t.Errorf("Expected error of type %v, got %v", reflect.TypeOf(cause), c.expectedErrorType)
+				}
+			} else if cause != c.expectedError {
+				t.Errorf("Expected %v error, got %v", c.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestDockerPush(t *testing.T) {
+	serverErr := fmt.Errorf("Error")
+	cases := []struct {
+		name              string
+		image             string
+		serverResponse    string
+		serverError       error
+		expectedError     error
+		expectedErrorType reflect.Type
+	}{
+		{
+			name:          "Test empty image name",
+			expectedError: errEmptyImageName,
+		},
+		{
+			name:           "Test image push",
+			image:          "test",
+			serverResponse: `{"stream":"Push successful"}`,
+		},
+		{
+			name:              "Test garbled server response",
+			image:             "test",
+			serverResponse:    `f9q*sa9das}`,
+			expectedErrorType: reflect.TypeOf(&json.SyntaxError{}),
+		},
+		{
+			name:          "Test server error",
+			image:         "test",
+			serverError:   serverErr,
+			expectedError: serverErr,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mockDockerImpl, _ := newDockerImpl(&mockImageClient{c.serverResponse, c.serverError}, nil)
+			err := mockDockerImpl.Push(c.image, os.Stdout, os.Stderr)
+			cause := errors.Cause(err)
+			if c.expectedErrorType != nil {
+				if reflect.TypeOf(cause) != c.expectedErrorType {
+					t.Errorf("Expected error of type %v, got %v", reflect.TypeOf(cause), c.expectedErrorType)
+				}
+			} else if cause != c.expectedError {
+				t.Errorf("Expected %v error, got %v", c.expectedError, err)
+			}
+		})
+	}
+}
+
+type mockContainerRunner struct {
+	createError error
+	startError  error
+	stopError   error
+	removeError error
+	logsError   error
+}
+
+func (m *mockContainerRunner) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error) {
+	return container.ContainerCreateCreatedBody{}, m.createError
+}
+func (m *mockContainerRunner) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {
+	return m.startError
+}
+func (m *mockContainerRunner) ContainerStop(ctx context.Context, container string, timeout *time.Duration) error {
+	return m.stopError
+}
+func (m *mockContainerRunner) ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error {
+	return m.removeError
+}
+func (m *mockContainerRunner) ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+	// Log uses StdCopy.stdcopy, which tests the first byte to see what is the type of the stream (stdcopy.Stdin = 0)
+	return &mockReadCloser{bytes.NewBufferString("\u0000" + "Hello there")}, m.logsError
+}
+func TestDockerRun(t *testing.T) {
+	serverError := fmt.Errorf("Error")
+	cases := []struct {
+		name          string
+		image         string
+		containerName string
+		config        *Runtime
+		expectedError error
+		createError   error
+		startError    error
+	}{
+		{
+			name:          "Test docker run - container start",
+			image:         "test",
+			containerName: "test",
+			config:        &Runtime{},
+		},
+		{
+			name:          "Test docker run - container create error",
+			image:         "test",
+			containerName: "test",
+			config:        &Runtime{},
+			createError:   serverError,
+			expectedError: serverError,
+		},
+		{
+			name:          "Test docker run - container start error",
+			image:         "test",
+			containerName: "test",
+			config:        &Runtime{},
+			startError:    serverError,
+			expectedError: serverError,
+		},
+		{
+			name:          "Test docker run - container with exposed port",
+			image:         "test",
+			containerName: "test",
+			config:        &Runtime{Ports: []int32{80}},
+		},
+		{
+			name:          "Test docker run - nil runtime",
+			image:         "test",
+			containerName: "test",
+			config:        nil,
+			expectedError: errNilRuntimeConfig,
+		},
+		{
+			name:          "Test docker run - empty image name",
+			containerName: "test",
+			config:        &Runtime{},
+			expectedError: errEmptyImageName,
+		},
+		{
+			name:          "Test docker run - empty container name",
+			image:         "test",
+			config:        &Runtime{},
+			expectedError: errEmptyContainerName,
+		},
+		{
+			name:          "Test docker run - port below range",
+			image:         "test",
+			containerName: "test",
+			config:        &Runtime{Ports: []int32{-1}},
+			expectedError: errInvalidPort(-1),
+		},
+		{
+			name:          "Test docker run - port above range",
+			image:         "test",
+			containerName: "test",
+			config:        &Runtime{Ports: []int32{70000}},
+			expectedError: errInvalidPort(70000),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mockDockerImpl, _ := newDockerImpl(nil, &mockContainerRunner{createError: c.createError, startError: c.startError})
+			err := mockDockerImpl.Run(c.image, c.containerName, c.config, os.Stdout, os.Stderr)
+			if errors.Cause(err) != c.expectedError {
+				t.Errorf("Expected %v error, got %v", c.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestDockerLogs(t *testing.T) {
+	serverError := fmt.Errorf("Error")
+	cases := []struct {
+		name          string
+		containerName string
+		expectedError error
+		logsError     error
+	}{
+		{
+			name:          "Test docker logs - success",
+			containerName: "test",
+		},
+		{
+			name:          "Test docker logs - empty container name",
+			expectedError: errEmptyContainerName,
+		},
+		{
+			name:          "Test docker logs - server error",
+			containerName: "test",
+			logsError:     serverError,
+			expectedError: serverError,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mockDockerImpl, _ := newDockerImpl(nil, &mockContainerRunner{logsError: c.logsError})
+			err := mockDockerImpl.Logs(c.containerName, os.Stderr, os.Stdout)
+			if errors.Cause(err) != c.expectedError {
+				t.Errorf("Expected %v error, got %v", c.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestDockerCancel(t *testing.T) {
+	serverError := fmt.Errorf("Error")
+	cases := []struct {
+		name          string
+		containerName string
+		expectedError error
+		stopError     error
+		removeError   error
+	}{
+		{
+			name:          "Test docker cancel - success",
+			containerName: "test",
+		},
+		{
+			name:          "Test docker cancel - empty container name",
+			expectedError: errEmptyContainerName,
+		},
+		{
+			name:          "Test docker cancel - stop error",
+			containerName: "test",
+			stopError:     serverError,
+			expectedError: serverError,
+		},
+		{
+			name:          "Test docker cancel - remove error",
+			containerName: "test",
+			removeError:   serverError,
+			expectedError: serverError,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mockDockerImpl, _ := newDockerImpl(nil, &mockContainerRunner{stopError: c.stopError, removeError: c.removeError})
+			err := mockDockerImpl.Cancel(c.containerName)
+			if errors.Cause(err) != c.expectedError {
+				t.Errorf("Expected %v error, got %v", c.expectedError, err)
+			}
+		})
+	}
+}

--- a/go/metaparticle/errors.go
+++ b/go/metaparticle/errors.go
@@ -1,0 +1,20 @@
+package metaparticle
+
+import (
+	"errors"
+	"fmt"
+)
+
+type errInvalidPort int32
+
+func (e errInvalidPort) Error() string {
+	return fmt.Sprintf("Invalid port number %v", int32(e))
+}
+
+var (
+	errEmptyContainerName         = errors.New("A container name must be specified")
+	errEmptyImageName             = errors.New("An image must be specified")
+	errNilRuntimeConfig           = errors.New("Runtime config must not be nil")
+	errEmptyContextDirectory      = errors.New("A context directory must be specified")
+	errInexistentContextDirectory = errors.New("Context directory does not exist")
+)

--- a/go/metaparticle/metaparticle.go
+++ b/go/metaparticle/metaparticle.go
@@ -139,8 +139,7 @@ func Containerize(r *Runtime, p *Package, f func()) {
 			panic(fmt.Sprintf("Could not get a builder for this package: %v", err))
 		}
 
-		name := "web"
-		image := "test"
+		image := p.Name
 
 		if len(p.Repository) != 0 {
 			image = p.Repository + "/" + image
@@ -162,13 +161,13 @@ func Containerize(r *Runtime, p *Package, f func()) {
 			}
 		}
 
-		err = exec.Run(image, name, r, os.Stdout, os.Stderr)
+		err = exec.Run(image, p.Name, r, os.Stdout, os.Stderr)
 		if err != nil {
-			panic(fmt.Sprintf("Error executing the container: %v", err))
+			panic(fmt.Sprintf("Error running the container: %v", err))
 		}
 
 		go func() {
-			exec.Logs(name, os.Stdout, os.Stderr)
+			exec.Logs(p.Name, os.Stdout, os.Stderr)
 		}()
 
 		signalChan := make(chan os.Signal, 1)
@@ -177,7 +176,7 @@ func Containerize(r *Runtime, p *Package, f func()) {
 		go func() {
 			for _ = range signalChan {
 				fmt.Println("Received interrupt, stopping container...")
-				exec.Cancel(name)
+				exec.Cancel(p.Name)
 				cleanupDone <- true
 			}
 		}()

--- a/go/metaparticle/test-data/test-project/main.go
+++ b/go/metaparticle/test-data/test-project/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello World")
+}


### PR DESCRIPTION
Resolves #55 and started work on #24.

`exec.Command` has been replaced by docker client API calls on docker's `Builder` and `Executor`.

Moved `AciRuntimeConfig` to aci_executor.go and replaced `AciConfig *AciRuntimeConfig` on metaparticle.go with `ExtraConfig interface{}`.

This way other runtimes can add their own extra configurations the same way the ACI runtime does.

Happy new year! :)