### PR TITLE
add go dep to the dockerfile for go example app

### DIFF
--- a/go/metaparticle/metaparticle.go
+++ b/go/metaparticle/metaparticle.go
@@ -111,9 +111,12 @@ func writeDockerfile(name string) error {
 WORKDIR /go/src/app
 COPY . .
 
-RUN go-wrapper download
+RUN go get -u github.com/golang/dep/cmd/dep
+
+RUN dep init
+
 RUN go-wrapper install
-	
+
 CMD ["go-wrapper", "run"]
 `
 	return ioutil.WriteFile("Dockerfile", []byte(contents), 0644)


### PR DESCRIPTION
I was trying the example and hit with the below error 
```
../../metaparticle/docker_impl.go:57: cannot use dockerClient (type *client.Client) as type dockerImageClient in field value:
	*client.Client does not implement dockerImageClient (wrong type for ImageBuild method)
		have ImageBuild("github.com/docker/docker/vendor/golang.org/x/net/context".Context, io.Reader, types.ImageBuildOptions) (types.ImageBuildResponse, error)
		want ImageBuild("context".Context, io.Reader, types.ImageBuildOptions) (types.ImageBuildResponse, error)
../../metaparticle/docker_impl.go:57: cannot use dockerClient (type *client.Client) as type dockerContainerRunner in field value:
	*client.Client does not implement dockerContainerRunner (wrong type for ContainerCreate method)
		have ContainerCreate("github.com/docker/docker/vendor/golang.org/x/net/context".Context, *container.Config, *container.HostConfig, *network.NetworkingConfig, string) (container.ContainerCreateCreatedBody, error)
 		want ContainerCreate("context".Context, *container.Config, *container.HostConfig, *network.NetworkingConfig, string) (container.ContainerCreateCreatedBody, error)
```
go-wrapper downloads the packages as it is and nested vendor folders can cause this issue. 
It would be nice if officail golang image comes with go dep but it isn't. Suggestions welcome