### PR TITLE
Update go tutorial.md

### DIFF
--- a/tutorials/go/tutorial.md
+++ b/tutorials/go/tutorial.md
@@ -62,7 +62,7 @@ build file, and then update the code.
 
 Run:
 ```sh
-$ go get https://github.com/metaparticle-io/package/go/metaparticle
+$ go get github.com/metaparticle-io/package/go/metaparticle
 ```
 
 Then update the code to read as follows:


### PR DESCRIPTION
You can't go get a package with http:// url scheme in it.
This is the error I get when I try to go get it.
```
package https:/github.com/metaparticle-io/package/go/metaparticle: "https://" not allowed in import path
```