### PR TITLE
Fix Python tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ go/**/Dockerfile
 
 python/**/MANIFEST
 python/**/dist
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     install:
     - pip install -r python/requirements.txt
     script:
-    - pytest
+    - python3 -m pytest --cov=. --cov-report=term-missing:skip-covered
   - language: node_js
     node_js: 8
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 sudo: enabled
 matrix:
   include:
-    #TODO: fix running tests in python 
-    # - language: python
-    #   python: 3.6
-    #   install:
-    #     - pip install -r python/requirements.txt
-    #   script:
-    #     - PYTHONPATH=./python python -m unittest discover -s ./python/metaparticle_pkg/
-    - language: node_js
-      node_js: 8
-      before_script:
-        - cd javascript/metaparticle-package
-        - npm install
-      script:
-        - npm test
+  - language: python
+    python: 3.6
+    install:
+    - pip install -r python/requirements.txt
+    script:
+    - pytest
+  - language: node_js
+    node_js: 8
+    before_script:
+    - cd javascript/metaparticle-package
+    - npm install
+    script:
+    - npm test

--- a/python/metaparticle_pkg/builder/docker_builder.py
+++ b/python/metaparticle_pkg/builder/docker_builder.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class DockerBuilder:
     def __init__(self):
-        self.docker_client = APIClient(version='auto') 
+        self.docker_client = APIClient(version='auto')
 
     def build(self, img, path='.'):
 

--- a/python/metaparticle_pkg/builder/test/test_docker_builder.py
+++ b/python/metaparticle_pkg/builder/test/test_docker_builder.py
@@ -3,42 +3,42 @@
 
 
 import unittest
-from mock import patch
-from metaparticle_pkg.builder import docker
+from unittest.mock import patch
+from metaparticle_pkg.builder import docker_builder
 
 
 class TestDockerBuilder(unittest.TestCase):
     '''Unit tests for DockerBuilder'''
 
     def setUp(self):
-        self.docker_builder = docker.DockerBuilder()
+        self.builder = docker_builder.DockerBuilder()
 
         # Input arguments
-        self.img = "test_image"
+        self.img = 'test_image'
 
-    @patch("metaparticle_pkg.builder.docker.subprocess")
-    def test_build(self, mocked_subprocess):
+    @patch('metaparticle_pkg.builder.docker_builder.APIClient.build')
+    def test_build(self, mocked_build):
         '''Test build method'''
 
-        # Expected argument called with
-        expected_args = ['docker', 'build', '-t', self.img, '.']
+        self.builder.build(self.img)
 
-        self.docker_builder.build(self.img)
+        mocked_build.assert_called_once_with(
+            path='.',
+            tag=self.img,
+            encoding='utf-8'
+        )
 
-        mocked_subprocess.check_call.assert_called_once_with(
-            expected_args)
-
-    @patch("metaparticle_pkg.builder.docker.subprocess")
-    def test_publish(self, mocked_subprocess):
+    @patch('metaparticle_pkg.builder.docker_builder.APIClient.push')
+    def test_publish(self, mocked_push):
         '''Test publish method'''
 
         # Expected argument called with
-        expected_args = ['docker', 'push', self.img]
+        self.builder.publish(self.img)
 
-        self.docker_builder.publish(self.img)
-
-        mocked_subprocess.check_call.assert_called_once_with(
-            expected_args)
+        mocked_push.ssert_called_once_with(
+            self.img,
+            stream=True
+        )
 
 
 if __name__ == '__main__':

--- a/python/metaparticle_pkg/runner/docker_runner.py
+++ b/python/metaparticle_pkg/runner/docker_runner.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 class DockerRunner:
     def __init__(self):
-        self.docker_client = APIClient(version='auto') 
+        self.docker_client = APIClient(version='auto')
 
     def run(self, img, name, options):
         ports = []

--- a/python/metaparticle_pkg/runner/test/test_docker_runner.py
+++ b/python/metaparticle_pkg/runner/test/test_docker_runner.py
@@ -3,70 +3,74 @@
 
 
 import unittest
-from mock import patch, call, MagicMock
-from metaparticle_pkg.runner import docker
+from unittest.mock import patch, call, MagicMock
+from metaparticle_pkg.runner import docker_runner
 
 
 class TestDockerRunner(unittest.TestCase):
     '''Unit tests for DockerRunner'''
 
     def setUp(self):
-        self.docker_runner = docker.DockerRunner()
+        self.runner = docker_runner.DockerRunner()
 
-    @patch("metaparticle_pkg.runner.docker.subprocess")
-    def test_run(self, mocked_subprocess):
+        # mock container
+        self.cid = '123'
+        self.runner.container = MagicMock()
+        self.runner.container.get = MagicMock(return_value=self.cid)
+
+    @patch('metaparticle_pkg.runner.docker_runner.APIClient.create_container')
+    @patch('metaparticle_pkg.runner.docker_runner.APIClient.start')
+    def test_run(self, mocked_start, mocked_create):
         '''Test Run method'''
 
         # Input arguments
         img = "test_image"
         name = "test_name"
+        port = '4562'
         options = MagicMock()
-        options.ports = ["4562"]
+        options.ports = [port]
 
         # Expected argument called with
-        expected_args = [
-            'docker', 'run', '-d',
-            '--name', 'test_name',
-            '-p', '4562:4562', 'test_image'
-        ]
+        self.runner.run(img, name, options)
 
-        self.docker_runner.run(img, name, options)
+        mocked_create.assert_called_once_with(
+            'test_image',
+            host_config={
+                'NetworkMode': 'default',
+                'PortBindings': {
+                    '{}/tcp'.format(port): [
+                        {
+                            'HostIp': '',
+                            'HostPort': port,
+                        }
+                    ]
+                }
+            },
+            name='test_name',
+            ports=[port]
+        )
 
-        mocked_subprocess.check_call.assert_called_once_with(
-            expected_args)
+        mocked_start.assert_called_once()
 
-    @patch("metaparticle_pkg.runner.docker.subprocess")
-    def test_logs(self, mocked_subprocess):
+    @patch('metaparticle_pkg.runner.docker_runner.APIClient.logs')
+    def test_logs(self, mocked_logs):
         '''Test logs method'''
 
-        # Input arguments
-        name = "test_name"
+        self.runner.logs()
+        mocked_logs.assert_called_once_with('123', follow=True, stream=True)
 
-        # Expected argument called with
-        expected_args = ['docker', 'logs', '-f', name]
-
-        self.docker_runner.logs(name)
-
-        mocked_subprocess.check_call.assert_called_once_with(
-            expected_args)
-
-    @patch("metaparticle_pkg.runner.docker.subprocess")
-    def test_cancel(self, mocked_subprocess):
+    @patch('metaparticle_pkg.runner.docker_runner.APIClient.kill')
+    @patch('metaparticle_pkg.runner.docker_runner.APIClient.remove_container')
+    def test_cancel(self, mocked_remove, mocked_kill):
         '''Test cancel method'''
 
         # Input arguments
         name = "test_name"
 
-        # Expected calls with supplied arguments
-        expected_call_list = [
-            call(['docker', 'kill', name]),
-            call(['docker', 'rm', name])
-        ]
+        self.runner.cancel(name)
 
-        self.docker_runner.cancel(name)
-
-        mocked_subprocess.check_call.assert_has_calls(
-            expected_call_list)
+        mocked_kill.assert_called_with(self.cid)
+        mocked_remove.assert_called_with(self.cid)
 
 
 if __name__ == '__main__':

--- a/python/metaparticle_pkg/runner/test/test_metaparticle.py
+++ b/python/metaparticle_pkg/runner/test/test_metaparticle.py
@@ -2,7 +2,7 @@
 '''Unit tests for MetaparticleRunner'''
 
 import unittest
-from mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock, mock_open
 from metaparticle_pkg.runner import metaparticle
 
 

--- a/python/metaparticle_pkg/test/test_containerize.py
+++ b/python/metaparticle_pkg/test/test_containerize.py
@@ -3,7 +3,7 @@
 
 import os as original_os
 import unittest
-from mock import patch, call, mock_open, MagicMock
+from unittest.mock import patch, call, mock_open, MagicMock
 from metaparticle_pkg import containerize
 from types import FunctionType
 

--- a/python/metaparticle_pkg/test/test_option.py
+++ b/python/metaparticle_pkg/test/test_option.py
@@ -3,7 +3,7 @@
 
 from sys import exit as real_exit
 import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from metaparticle_pkg import option
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 docker==2.7.0
 pytest
+pytest-cov

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,2 @@
 docker==2.7.0
+pytest


### PR DESCRIPTION
This PR introduces changes for python tests to match with latest python runners and builders.

* Enable python tests in travis
* Adjust tests to match with running docker commands using API
* Use `pytest` to run tets
* Report coverage