### PR TITLE
fix PEP8 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - pip install -r python/requirements.txt
     script:
     - python3 -m pytest --cov=. --cov-report=term-missing:skip-covered
+    - python3 -m flake8 --config python/setup.cfg
 
   - language: node_js
     node_js: 8

--- a/python/examples/web/web.py
+++ b/python/examples/web/web.py
@@ -8,6 +8,7 @@ OK = 200
 
 port = 8080
 
+
 class MyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     def do_GET(self):
         self.send_response(OK)
@@ -15,10 +16,12 @@ class MyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         self.end_headers()
         self.wfile.write("Hello Metaparticle [{}] @ {}\n".format(self.path, socket.gethostname()).encode('UTF-8'))
         print("request for {}".format(self.path))
+
     def do_HEAD(self):
         self.send_response(OK)
         self.send_header("Content-type", "text/plain")
         self.end_headers()
+
 
 @Containerize(
     package={'name': 'web', 'repository': 'docker.io/brendanburns'},
@@ -28,6 +31,7 @@ def main():
     Handler = MyHandler
     httpd = socketserver.TCPServer(("", port), Handler)
     httpd.serve_forever()
+
 
 if __name__ == '__main__':
     main()

--- a/python/metaparticle_pkg/__init__.py
+++ b/python/metaparticle_pkg/__init__.py
@@ -1,1 +1,3 @@
 from metaparticle_pkg.containerize import Containerize
+
+__all__ = [Containerize]

--- a/python/metaparticle_pkg/builder/__init__.py
+++ b/python/metaparticle_pkg/builder/__init__.py
@@ -1,4 +1,6 @@
 from metaparticle_pkg.builder.docker_builder import DockerBuilder
+
+
 def select(spec):
     if spec == 'docker':
         return DockerBuilder()

--- a/python/metaparticle_pkg/option.py
+++ b/python/metaparticle_pkg/option.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import sys
 import os
 
+
 def load(cls, options):
     if not isinstance(options, dict):
         sys.stderr.write("Must provide an options dict.")
@@ -16,23 +17,31 @@ def load(cls, options):
         sys.stderr.write("Unexpected option(s) provided: %s" % error)
         sys.exit(1)
 
+
 class RuntimeOptions(namedtuple('Runtime', 'executor replicas ports publicAddress shardSpec jobSpec')):
     required_options = []
+
     def __new__(cls, executor='docker', replicas=0, ports=[], publicAddress=[], shardSpec=None, jobSpec=None):
         return super(RuntimeOptions, cls).__new__(cls, executor, replicas, ports, publicAddress, shardSpec, jobSpec)
 
+
 class ShardSpec(namedtuple('ShardSpec', 'shards shardExpression')):
     required_options = []
+
     def __new__(cls, shards=0, shardExpression='.*'):
         return super(ShardSpec, cls).__new__(cls, shards, shardExpression)
 
+
 class JobSpec(namedtuple('JobSpec', 'iterations')):
     required_options = ['iterations']
+
     def __new__(cls, iterations=0):
         return super(JobSpec, cls).__new__(cls, iterations)
 
+
 class PackageOptions(namedtuple('Package', 'repository name builder publish verbose quiet py_version')):
     required_options = ['repository']
+
     def __new__(cls, repository, name, builder='docker', publish=False, verbose=True, quiet=False, py_version=3, dockerfile=None):
         name = name if name else os.path.basename(os.getcwd())
         return super(PackageOptions, cls).__new__(cls, repository, name, builder, publish, verbose, quiet, py_version)

--- a/python/metaparticle_pkg/runner/__init__.py
+++ b/python/metaparticle_pkg/runner/__init__.py
@@ -1,9 +1,11 @@
 from metaparticle_pkg.runner.docker_runner import DockerRunner
 from metaparticle_pkg.runner.metaparticle import MetaparticleRunner
 
+
 def select(spec):
     if spec == 'docker':
         return DockerRunner()
     if spec == 'metaparticle':
         return MetaparticleRunner()
+
     raise Exception('Unknown spec {}'.format(spec))

--- a/python/metaparticle_pkg/runner/metaparticle.py
+++ b/python/metaparticle_pkg/runner/metaparticle.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 
+
 class MetaparticleRunner:
     def cancel(self, name):
         subprocess.check_call(['mp-compiler', '-f', '.metaparticle/spec.json', '--delete'])
@@ -19,19 +20,19 @@ class MetaparticleRunner:
         return result
 
     def run(self, img, name, options):
-        svc =  {
+        svc = {
             "name": name,
             "guid": 1234567,
         }
 
         if options.replicas > 0 or options.shardSpec is not None:
-            svc["services"] = [ 
+            svc["services"] = [
                 {
                     "name": name,
                     "replicas": options.replicas,
                     "shardSpec": options.shardSpec,
                     "containers": [
-                        { "image": img }
+                        {"image": img}
                     ],
                     "ports": self.ports(options.ports)
                 }
@@ -46,7 +47,7 @@ class MetaparticleRunner:
                     "name": name,
                     "replicas": options.jobSpec['iterations'],
                     "containers": [
-                        { "image": img }
+                        {"image": img}
                     ]
                 }
             ]
@@ -56,5 +57,5 @@ class MetaparticleRunner:
 
         with open('.metaparticle/spec.json', 'w') as out:
             json.dump(svc, out)
-    
+
         subprocess.check_call(['mp-compiler', '-f', '.metaparticle/spec.json'])

--- a/python/metaparticle_pkg/runner/test/test_docker_runner.py
+++ b/python/metaparticle_pkg/runner/test/test_docker_runner.py
@@ -3,7 +3,7 @@
 
 
 import unittest
-from unittest.mock import patch, call, MagicMock
+from unittest.mock import patch, MagicMock
 from metaparticle_pkg.runner import docker_runner
 
 

--- a/python/metaparticle_pkg/test/test_containerize.py
+++ b/python/metaparticle_pkg/test/test_containerize.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 '''Unit tests for containerize module'''
 
-import os as original_os
 import unittest
-from unittest.mock import patch, call, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock
 from metaparticle_pkg import containerize
 from types import FunctionType
 

--- a/python/metaparticle_pkg/version.json
+++ b/python/metaparticle_pkg/version.json
@@ -1,0 +1,5 @@
+{
+"version": "0.6.3",
+"license": "MIT",
+"status": "Development",
+}

--- a/python/metaparticle_pkg/version.py
+++ b/python/metaparticle_pkg/version.py
@@ -1,3 +1,0 @@
-__version__ = '0.6.3'
-__license__ = "MIT"
-__status__ = "Development"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 docker==2.7.0
+flake8
 pytest
 pytest-cov

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,3 +1,5 @@
 [metadata]
 description-file = README.md
 
+[flake8]
+max-line-length = 160

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,12 +1,13 @@
 import setuptools
+import json
 
-exec(open('./metaparticle_pkg/version.py').read())
+config = json.loads('./metaparticle_pkg/version.json')
 
 setuptools.setup(
     name='metaparticle_pkg',
-    version=__version__,
+    version=config['version'],
     url='https://github.com/metaparticle-io/package/tree/master/python',
-    license=__license__,
+    license=config['license'],
     description='Easily containerize your python application',
     author='Metaparticle Authors',
     packages=setuptools.find_packages(),
@@ -14,10 +15,11 @@ setuptools.setup(
     include_package_data=False,
     zip_safe=False,
     install_requires=['docker==2.7.0'],
+    test_require=['pytest', 'flake8'],
     platforms='linux',
     keywords=['kubernetes', 'docker', 'container', 'metaparticle'],
     # latest from https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Intended Audience :: Developers',

--- a/tutorials/python/web.py
+++ b/tutorials/python/web.py
@@ -7,6 +7,7 @@ OK = 200
 
 port = 8080
 
+
 class MyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     def do_GET(self):
         self.send_response(OK)
@@ -14,15 +15,18 @@ class MyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         self.end_headers()
         self.wfile.write("Hello Metparticle [{}] @ {}\n".format(self.path, socket.gethostname()).encode('UTF-8'))
         print("request for {}".format(self.path))
+
     def do_HEAD(self):
         self.send_response(OK)
         self.send_header("Content-type", "text/plain")
         self.end_headers()
 
+
 def main():
     Handler = MyHandler
     httpd = socketserver.TCPServer(("", port), Handler)
     httpd.serve_forever()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR is changing Python code to match PEP8.

Additional changes:

- read version from JSON and parse it in `setup.py`
- run PEP8 tests in travis
- set E501 - max line length to 160 characters