### PR TITLE
Docker registry auth

### DIFF
--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -189,6 +189,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a56b7216d4180806a89bfbd36f26294cb1433eaf4c0c1d747ada132e388667a3"
+  inputs-digest = "d7ca45102d18ffe38266dfe382e6de87300eeba84e7faceed5059a53e4002d80"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -31,7 +31,7 @@
   revision = "f4118485915abb8b163442717326597908eee6aa"
 
 
-[[constraint]]
+[[override]]
   name = "github.com/Azure/azure-sdk-for-go"
   version = "12.2.0-beta"
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,4 +1,5 @@
 # Metaparticle/Package for Go
+
 Metaparticle/Package is a collection of libraries intended to
 make building and deploying containers a seamless and idiomatic
 experience for developers.
@@ -6,6 +7,7 @@ experience for developers.
 This is the implementation for Go.
 
 ## Introduction
+
 Metaparticle/Package simplifies and centralizes the task of
 building and deploying a container image.
 
@@ -37,9 +39,12 @@ import(
 func main() {
     metaparticle.Containerize(
         &metaparticle.Runtime{
-            Executor:        "docker"},
-        &metaparticle.Package{Repository: "xfernando",
-            Builder: "docker"},
+            Executor:   "docker",
+        },
+        &metaparticle.Package{
+            Repository: "docker.io/brendanburns",
+            Builder:    "docker"
+        },
         func() {
             fmt.Println("Hello World")
         })
@@ -47,3 +52,46 @@ func main() {
 ```
 
 Then you only have to do `go run main.go`, and a container will be built and deployed to your docker instance.
+
+## Registry authentication
+
+If you want your image pushed to your registry, there are two things needed.
+
+First you need to add `Publish: true` to the `metaparticle.Package` annotation. Changing the previous example we get:
+
+```go
+package main
+
+import(
+    "fmt"
+    "github.com/metaparticle-io/package/go/metaparticle"
+)
+
+func main() {
+    metaparticle.Containerize(
+        &metaparticle.Runtime{
+            Executor:   "docker",
+        },
+        &metaparticle.Package{
+            Repository: "docker.io/brendanburns",
+            Builder:    "docker",
+            Publish:    true,
+        },
+        func() {
+            fmt.Println("Hello World")
+        })
+}
+```
+
+Then you need to set two environment variables, `MP_REGISTRY_USERNAME` with your registry user, and `MP_REGISTRY_PASSWORD` with
+your registry password. Or you can pass them in the shell when starting the program:
+
+```bash
+env MP_REGISTRY_USERNAME=youruser MP_REGISTRY_PASSWORD=yourpassword go run main.go
+```
+
+These are used to generate the authorization string passed to the docker server. When you execute `go run main.go`
+with both set, they'll be used to authenticate you to the remote registry.
+
+The name of the repository must be a canonical name (e.g. docker.io/brendanburns). So, if you're using docker hub
+you can't omit the docker.io part of the repository name.

--- a/go/examples/sharded/main.go
+++ b/go/examples/sharded/main.go
@@ -27,7 +27,7 @@ func main() {
 		},
 		&metaparticle.Package{
 			Name:       "metaparticle-shard-demo",
-			Repository: "brendanburns",
+			Repository: "docker.io/brendanburns",
 			Builder:    "docker",
 			Verbose:    true,
 			Publish:    true,

--- a/go/examples/simple/main.go
+++ b/go/examples/simple/main.go
@@ -12,7 +12,7 @@ func main() {
 			Executor: "docker",
 		},
 		&metaparticle.Package{
-			Repository: "brendanburns",
+			Repository: "docker.io/brendanburns",
 			Name:       "go-simple",
 			Builder:    "docker",
 		},

--- a/go/examples/web-aci/main.go
+++ b/go/examples/web-aci/main.go
@@ -26,7 +26,7 @@ func main() {
 		},
 		&metaparticle.Package{
 			Name:       "metaparticle-aci-demo",
-			Repository: "radumatei",
+			Repository: "docker.io/radumatei",
 			Builder:    "docker",
 			Verbose:    true,
 			Publish:    true,

--- a/go/examples/webapp/main.go
+++ b/go/examples/webapp/main.go
@@ -26,7 +26,7 @@ func main() {
 		},
 		&metaparticle.Package{
 			Name:       "metaparticle-web-demo",
-			Repository: "brendanburns",
+			Repository: "docker.io/brendanburns",
 			Builder:    "docker",
 			Verbose:    true,
 			Publish:    true,

--- a/go/metaparticle/metaparticle.go
+++ b/go/metaparticle/metaparticle.go
@@ -158,7 +158,7 @@ func Containerize(r *Runtime, p *Package, f func()) {
 		if p.Publish {
 			err = builder.Push(image, os.Stdout, os.Stderr)
 			if err != nil {
-				panic(fmt.Sprintf("Could not push the image to the repository: %v", err))
+				panic(fmt.Sprintf("Could not push image \"%v\" to the repository: %v", image, err))
 			}
 		}
 


### PR DESCRIPTION
This pull request resolves #72 by using two environment variables: `MP_REGISTRY_USER` and `MP_REGISTRY_PASSWORD` to authenticate pull requests against the remote registry.

Also removes a lot of code used for displaying server responses since using `DisplayJSONMessagesStream` from docker's `jsonmessage` package makes it way simpler.