### PR TITLE
Initial Set of Unit Tests For DotNet Metaparticle.Package

### DIFF
--- a/dotnet/Metaparticle.Package.Tests/DriverTests.cs
+++ b/dotnet/Metaparticle.Package.Tests/DriverTests.cs
@@ -1,0 +1,39 @@
+using System;
+using NSubstitute;
+using Xunit;
+using static Metaparticle.Package.Driver;
+using RuntimeConfig = Metaparticle.Runtime.Config;
+
+namespace Metaparticle.Package.Tests
+{
+    public class DriverTests
+    {
+        static int testOutput = 0;
+
+        [Metaparticle.Runtime.Config]
+        [Metaparticle.Package.Config(Verbose = true,
+		Publish = false, Repository = "testrepo")] 
+        private static void TestActionInContainer(string[] args) => Containerize (args, () =>
+        {
+            testOutput = 1;
+        });
+
+        [Fact]
+        public void Containerize_Executes_Action_When_In_Container_Equals_True()
+        {
+            testOutput = 0;
+            Environment.SetEnvironmentVariable("METAPARTICLE_IN_CONTAINER", "true");
+            TestActionInContainer(null);
+            Assert.True(1 == testOutput);
+        }
+
+        [Fact]
+        public void Containerize_Executes_Action_When_In_Container_Equals_1()
+        {
+            testOutput = 0;
+            Environment.SetEnvironmentVariable("METAPARTICLE_IN_CONTAINER", "1");
+            TestActionInContainer(null);
+            Assert.True(1 == testOutput);
+        }
+    }
+}

--- a/dotnet/Metaparticle.Package.Tests/Metaparticle.Package.Tests.csproj
+++ b/dotnet/Metaparticle.Package.Tests/Metaparticle.Package.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <ProjectReference Include="..\Metaparticle.Package\Metaparticle.Package.csproj" />
   </ItemGroup>

--- a/dotnet/Metaparticle.Package.Tests/Metaparticle.Package.Tests.csproj
+++ b/dotnet/Metaparticle.Package.Tests/Metaparticle.Package.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <ProjectReference Include="..\Metaparticle.Package\Metaparticle.Package.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/Metaparticle.Package.Tests/MetaparticleTests.cs
+++ b/dotnet/Metaparticle.Package.Tests/MetaparticleTests.cs
@@ -4,7 +4,7 @@ using Metaparticle.Package;
 
 namespace Metaparticle.Package.Tests
 {
-    public class MetaparticleTests
+    public class ConfigTests
     {
         [Fact]
         public void Config_Loads_Environment_Variables()

--- a/dotnet/Metaparticle.Package.Tests/MetaparticleTests.cs
+++ b/dotnet/Metaparticle.Package.Tests/MetaparticleTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Xunit;
+using Metaparticle.Package;
+
+namespace Metaparticle.Package.Tests
+{
+    public class MetaparticleTests
+    {
+        [Fact]
+        public void Config_Loads_Environment_Variables()
+        {
+            Environment.SetEnvironmentVariable("METAPARTICLE_CONFIG_REPOSITORY", "testRepo");
+            Environment.SetEnvironmentVariable("METAPARTICLE_CONFIG_PUBLISH", "true");
+            var config = new Config();
+            Assert.True("testRepo" == config.Repository);
+            Assert.True(true == config.Publish); 
+        }
+
+        [Fact]
+        public void Config_Defaults_Builder_To_Docker()
+        {
+            var config = new Config();
+            Assert.True("docker" == config.Builder);
+        }
+    }
+}


### PR DESCRIPTION
# Unit Tests for Dotnet Metaparticle.Package

## Purpose

To introduce an initial set of tests for the dotnet Metaparticle.Package to help resolve https://github.com/metaparticle-io/package/issues/3

## Details

Added unit tests for 

- Config
- Driver (Basic coverage - needs extending)

## Tools Used

- XUnit
- NSubstitute

## Whats next?

I will continue to add more coverage which will likely involve refactoring the existing code base and decoupling it further.