### PR TITLE
Adding virtualenv pip requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,3 +2,4 @@ docker==2.7.0
 flake8
 pytest
 pytest-cov
+virtualenv


### PR DESCRIPTION
# TL;DR
```requirements.txt+=virtualenv```

# Background

- I tired the Readme.md.
- `make venv` didn't work
- manually installed `pip3 install virtualenv` then `make venv` worked. Hence the PR