### PR TITLE
[Python] Readme.md Fixing TYPO

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -50,6 +50,6 @@ cd package/python
 make venv
 source venv/bin/activate
 
-cd examples
+cd examples/simple
 python example.py
 ```


### PR DESCRIPTION
Python Readme.md example had an old-path. 
This PR fixes the problem